### PR TITLE
Make the compilation of sundials optional and add static library option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ bindgen = "0.42.3"
 cmake = "0.1.35"
 
 [features]
-default = ["arkode", "cvode", "ida", "kinsol"]
+default = ["static_libraries", "arkode", "cvode", "ida", "kinsol"]
+static_libraries = []
+build_libraries = []
 arkode = []
 cvode = []
 cvodes = []


### PR DESCRIPTION
This is a rough first pass at making the compilation of sundials optional so that if you've already got it you don't need to build it again. Also I added the capability to select whether dynamic or static libraries are used, I currently have it defaulting to static libraries as I think that is the better option on MacOS and Windows but totally open to using dynamic as default.

I think I could really use this project and am excited to offer this tiny contribution.